### PR TITLE
Migrated to v2 of the REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ I'm no Ruby expert so when I asked three different developers for their library 
 
 Usage
 =====
-* Change the URL subdomain for your account
-* First argument: Your API key (I recommend generating a read-only API key)
-* Second argument: The ID of the appropriate service id.
+* First argument: Your v2 REST API key (I recommend generating a read-only API key)
+* Second argument: The ID of the appropriate service
 
 Sample Output
 =============
-On-Call Engineer: John Smith - john.smith@yourcompany.com - 1112223333
+On-Call Engineer: John Smith. Email(s): john.smith@yourcompany.com, john.smith@gmail.com. Phone Number(s): 1112223333.
 
 More Information
 ================
-* PagerDuty API documentation => http://developer.pagerduty.com/documentation/rest
+* PagerDuty API documentation => https://developer.pagerduty.com/
 * http://support.pagerduty.com/entries/23586358-Determine-Who-Is-On-Call

--- a/with_curb.rb
+++ b/with_curb.rb
@@ -87,6 +87,6 @@ if user_phones.any?
   end
   output = output.chomp(', ')
 else
-  output << 'N/A'
+  output << 'N/A.'
 end
 puts output

--- a/with_curb.rb
+++ b/with_curb.rb
@@ -1,44 +1,92 @@
+#!/usr/bin/env ruby
+
 require 'curb'
 require 'json'
 require 'time'
- 
-# Get the userid of person from the rendered schedule 
-schedule_url = "https://yourdomain.pagerduty.com/api/v1/schedules/#{ARGV[1]}"
-schedule_params = { :since => Time.now.utc.iso8601(), 
-                    :until => (Time.now.utc + 60).iso8601() }
- 
-Curl::postalize(schedule_params)
- 
-final_url = Curl::urlalize(schedule_url, schedule_params)
- 
-http = Curl.get(final_url) do|http|
-  http.headers["Content-type"] = "application/json"
-  http.headers["Authorization"] = "Token token=#{ARGV[0]}"  # read/only api token
+
+# Get the ID of the escalation policy associated with the service
+url = "https://api.pagerduty.com/services/#{ARGV[1]}"
+
+http = Curl.get(url) do |curl|
+  curl.headers['Content-type'] = 'application/json'
+  curl.headers['Authorization'] = "Token token=#{ARGV[0]}" # read/only api token
+  curl.headers['Accept'] = 'application/vnd.pagerduty+json;version=2'
 end
- 
+
 if http.response_code == 200
-  schedule_result = JSON.parse(http.body_str)
-  user_id = schedule_result["schedule"]["schedule_layers"][0]["rendered_schedule_entries"][0]["user"]["id"]
-  user_name = schedule_result["schedule"]["schedule_layers"][0]["rendered_schedule_entries"][0]["user"]["name"]
+  result = JSON.parse(http.body_str)
+  escalation_policy_id = result['service']['escalation_policy']['id']
 else
-  puts "Oh snap! Something went wrong."
+  puts 'Oh snap! Something went wrong.'
 end
- 
-# Get the contact information of the userid  
-user_url = "https://yourdomain.pagerduty.com/api/v1/users/#{user_id}/contact_methods"
- 
-http = Curl.get(user_url) do|http|
-  http.headers["Content-type"] = "application/json"
-  http.headers["Authorization"] = "Token token=#{ARGV[0]}"  # read/only api token
+
+# Get the currently on-call user
+url = 'https://api.pagerduty.com/oncalls'
+params = { 'since' => Time.now.utc.iso8601,
+           'until' => (Time.now.utc + 60).iso8601,
+           'escalation_policy_ids[]' => escalation_policy_id }
+
+Curl.postalize(params)
+
+url = Curl.urlalize(url, params)
+
+http = Curl.get(url) do |curl|
+  curl.headers['Content-type'] = 'application/json'
+  curl.headers['Authorization'] = "Token token=#{ARGV[0]}" # read/only api token
+  curl.headers['Accept'] = 'application/vnd.pagerduty+json;version=2'
 end
- 
+
 if http.response_code == 200
-  user_result = JSON.parse(http.body_str)
-  user_email = user_result["contact_methods"][0]["email"]
-  user_phone = user_result["contact_methods"][1]["phone_number"]
+  result = JSON.parse(http.body_str)
+  user_id = result['oncalls'][0]['user']['id']
+  user_name = result['oncalls'][0]['user']['summary']
 else
-  puts "Oh snap! Something went wrong."
+  puts 'Oh snap! Something went wrong.'
 end
- 
+
+# Get the contact information of the userid
+url = "https://api.pagerduty.com/users/#{user_id}/contact_methods"
+
+http = Curl.get(url) do |curl|
+  curl.headers['Content-type'] = 'application/json'
+  curl.headers['Authorization'] = "Token token=#{ARGV[0]}" # read/only api token
+  curl.headers['Accept'] = 'application/vnd.pagerduty+json;version=2'
+end
+
+if http.response_code == 200
+  result = JSON.parse(http.body_str)
+  user_emails = []
+  user_phones = []
+  result['contact_methods'].each do |method|
+    if method['type'] == 'email_contact_method'
+      user_emails.push(method['address'])
+    elsif method['type'] == 'phone_contact_method'
+      user_phones.push(method['address'])
+    end
+  end
+else
+  puts 'Oh snap! Something went wrong.'
+end
+
 # Print out the On-Call User information
-puts "On-Call Engineer: #{user_name} - #{user_email} - #{user_phone}"
+output = "On-Call Engineer: #{user_name}. Email(s): "
+if user_emails.any?
+  user_emails.each do |email|
+    output << email
+    output << ', '
+  end
+  output = output.chomp(', ')
+else
+  output << 'N/A'
+end
+output << '. Phone Number(s): '
+if user_phones.any?
+  user_phones.each do |num|
+    output << num
+    output << ', '
+  end
+  output = output.chomp(', ')
+else
+  output << 'N/A'
+end
+puts output

--- a/with_faraday.rb
+++ b/with_faraday.rb
@@ -85,6 +85,6 @@ if user_phones.any?
   end
   output = output.chomp(', ')
 else
-  output << 'N/A'
+  output << 'N/A.'
 end
 puts output

--- a/with_faraday.rb
+++ b/with_faraday.rb
@@ -1,42 +1,90 @@
+#!/usr/bin/env ruby
+
 require 'faraday'
 require 'json'
 require 'time'
 
-# Get the userid of person from the rendered schedule 
-conn = Faraday.new(:url => 'https://yourdomain.pagerduty.com') do |faraday|
+# Get the escalation_policy_id from the service
+conn = Faraday.new('url' => 'https://api.pagerduty.com/') do |faraday|
   faraday.request :url_encoded
   faraday.adapter Faraday.default_adapter
   faraday.headers['Content-type'] = 'application/json'
   faraday.headers['Authorization'] = "Token token=#{ARGV[0]}"
-  faraday.params['since'] = Time.now.utc.iso8601()
-  faraday.params['until'] = (Time.now.utc + 60).iso8601()
+  faraday.headers['Accept'] = 'application/vnd.pagerduty+json;version=2'
 end
 
-response = conn.get "/api/v1/schedules/#{ARGV[1]}"
+response = conn.get "/services/#{ARGV[1]}"
 if response.status == 200
-  schedule_result = JSON.parse(response.body)
-  user_id = schedule_result["schedule"]["schedule_layers"][0]["rendered_schedule_entries"][0]["user"]["id"]
-  user_name = schedule_result["schedule"]["schedule_layers"][0]["rendered_schedule_entries"][0]["user"]["name"]
+  result = JSON.parse(response.body)
+  escalation_policy_id = result['service']['escalation_policy']['id']
 else
-  puts "Oh snap! Something went wrong."
+  puts 'Oh snap! Something went wrong.'
 end
 
-# Get the contact information of the userid  
-conn = Faraday.new(:url => 'https://yourdomain.pagerduty.com') do |faraday|
+# Get the currently on-call user
+conn = Faraday.new('url' => 'https://api.pagerduty.com') do |faraday|
+  faraday.request :url_encoded
+  faraday.adapter Faraday.default_adapter
+  faraday.headers['Content-type'] = 'application/json'
+  faraday.headers['Authorization'] = "Token token=#{ARGV[0]}"
+  faraday.headers['Accept'] = 'application/vnd.pagerduty+json;version=2'
+  faraday.params['since'] = Time.now.utc.iso8601
+  faraday.params['until'] = (Time.now.utc + 60).iso8601
+  faraday.params['escalation_policy_ids[]'] = escalation_policy_id
+end
+
+response = conn.get '/oncalls'
+if response.status == 200
+  result = JSON.parse(response.body)
+  user_id = result['oncalls'][0]['user']['id']
+  user_name = result['oncalls'][0]['user']['summary']
+else
+  puts 'Oh snap! Something went wrong.'
+end
+
+# Get the contact information of the user
+conn = Faraday.new('url' => 'https://api.pagerduty.com') do |faraday|
   faraday.request :url_encoded
   faraday.adapter Faraday.default_adapter
   faraday.headers['Content-type'] = 'application/json'
   faraday.headers['Authorization'] = "Token token=#{ARGV[0]}"
 end
 
-response = conn.get "/api/v1/users/#{user_id}/contact_methods"
+response = conn.get "/users/#{user_id}/contact_methods"
 if response.status == 200
-  user_result = JSON.parse(response.body)
-  user_email = user_result["contact_methods"][0]["email"]
-  user_phone = user_result["contact_methods"][1]["phone_number"]
+  result = JSON.parse(response.body)
+  user_emails = []
+  user_phones = []
+  result['contact_methods'].each do |method|
+    if method['type'] == 'email_contact_method'
+      user_emails.push(method['address'])
+    elsif method['type'] == 'phone_contact_method'
+      user_phones.push(method['address'])
+    end
+  end
 else
-  puts "Oh snap! Something went wrong."
+  puts 'Oh snap! Something went wrong.'
 end
- 
+
 # Print out the On-Call User information
-puts "On-Call Engineer: #{user_name} - #{user_email} - #{user_phone}"
+output = "On-Call Engineer: #{user_name}. Email(s): "
+if user_emails.any?
+  user_emails.each do |email|
+    output << email
+    output << ', '
+  end
+  output = output.chomp(', ')
+else
+  output << 'N/A'
+end
+output << '. Phone Number(s): '
+if user_phones.any?
+  user_phones.each do |num|
+    output << num
+    output << ', '
+  end
+  output = output.chomp(', ')
+else
+  output << 'N/A'
+end
+puts output

--- a/with_net_http.rb
+++ b/with_net_http.rb
@@ -97,6 +97,6 @@ if user_phones.any?
   end
   output = output.chomp(', ')
 else
-  output << 'N/A'
+  output << 'N/A.'
 end
 puts output

--- a/with_net_http.rb
+++ b/with_net_http.rb
@@ -1,51 +1,102 @@
+#!/usr/bin/env ruby
+
 require 'net/https'
 require 'json'
 require 'time'
 
-# Get the userid of person from the rendered schedule 
-schedule_url = URI.parse "https://yourdomain.pagerduty.com/api/v1/schedules/#{ARGV[1]}"
-http = Net::HTTP.new schedule_url.host, schedule_url.port
+# Get the escalation_policy_id from the service
+url = URI.parse "https://api.pagerduty.com/services/#{ARGV[1]}"
+http = Net::HTTP.new url.host, url.port
 http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 http.use_ssl = true
- 
-schedule_params = { :since => Time.now.utc.iso8601(), 
-                    :until => (Time.now.utc + 60).iso8601() }
 
-schedule_url.query = URI.encode_www_form(schedule_params)
- 
-request = Net::HTTP::Get.new(schedule_url.request_uri)
-request["Content-type"] = "application/json"
-request["Authorization"] = "Token token=#{ARGV[0]}"  # read/only api token
- 
-schedule_response = http.request(request)
- 
-if schedule_response.code == "200"
-  schedule_result = JSON.parse(schedule_response.body)
-  user_id = schedule_result["schedule"]["schedule_layers"][0]["rendered_schedule_entries"][0]["user"]["id"]
-  user_name = schedule_result["schedule"]["schedule_layers"][0]["rendered_schedule_entries"][0]["user"]["name"]
+request = Net::HTTP::Get.new(url.request_uri)
+request['Content-type'] = 'application/json'
+request['Authorization'] = "Token token=#{ARGV[0]}" # read/only api token
+request['Accept'] = 'application/vnd.pagerduty+json;version=2'
+
+response = http.request(request)
+
+if response.code == '200'
+  result = JSON.parse(response.body)
+  escalation_policy_id = result['service']['escalation_policy']['id']
 else
-  puts "Oh snap! Something went wrong."
+  puts 'Oh snap! Something went wrong.'
 end
- 
-# Get the contact information of the userid 
-user_url = URI.parse "https://yourdomain.pagerduty.com/api/v1/users/#{user_id}/contact_methods"
-http = Net::HTTP.new user_url.host, user_url.port
+
+# Get the currently on-call user
+url = URI.parse 'https://api.pagerduty.com/oncalls'
+http = Net::HTTP.new url.host, url.port
 http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 http.use_ssl = true
- 
-request = Net::HTTP::Get.new(user_url.request_uri)
-request["Content-type"] = "application/json"
-request["Authorization"] = "Token token=#{ARGV[0]}"  # read/only api token
- 
-user_response = http.request(request)
- 
-if user_response.code == "200"
-  user_result = JSON.parse(user_response.body)
-  user_email = user_result["contact_methods"][0]["email"]
-  user_phone = user_result["contact_methods"][1]["phone_number"]
+
+params = { 'since' => Time.now.utc.iso8601,
+           'until' => (Time.now.utc + 60).iso8601,
+           'escalation_policy_ids[]' => escalation_policy_id }
+url.query = URI.encode_www_form(params)
+
+request = Net::HTTP::Get.new(url.request_uri)
+request['Content-type'] = 'application/json'
+request['Authorization'] = "Token token=#{ARGV[0]}" # read/only api token
+request['Accept'] = 'application/vnd.pagerduty+json;version=2'
+
+response = http.request(request)
+
+if response.code == '200'
+  result = JSON.parse(response.body)
+  user_id = result['oncalls'][0]['user']['id']
+  user_name = result['oncalls'][0]['user']['summary']
 else
-  puts "Oh snap! Something went wrong."
+  puts 'Oh snap! Something went wrong.'
 end
- 
+
+# Get the contact information of the user
+url = URI.parse "https://api.pagerduty.com/users/#{user_id}/contact_methods"
+http = Net::HTTP.new url.host, url.port
+http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+http.use_ssl = true
+
+request = Net::HTTP::Get.new(url.request_uri)
+request['Content-type'] = 'application/json'
+request['Authorization'] = "Token token=#{ARGV[0]}" # read/only api token
+request['Accept'] = 'application/vnd.pagerduty+json;version=2'
+
+response = http.request(request)
+
+if response.code == '200'
+  result = JSON.parse(response.body)
+  user_emails = []
+  user_phones = []
+  result['contact_methods'].each do |method|
+    if method['type'] == 'email_contact_method'
+      user_emails.push(method['address'])
+    elsif method['type'] == 'phone_contact_method'
+      user_phones.push(method['address'])
+    end
+  end
+else
+  puts 'Oh snap! Something went wrong.'
+end
+
 # Print out the On-Call User information
-puts "On-Call Engineer: #{user_name} - #{user_email} - #{user_phone}"
+output = "On-Call Engineer: #{user_name}. Email(s): "
+if user_emails.any?
+  user_emails.each do |email|
+    output << email
+    output << ', '
+  end
+  output = output.chomp(', ')
+else
+  output << 'N/A'
+end
+output << '. Phone Number(s): '
+if user_phones.any?
+  user_phones.each do |num|
+    output << num
+    output << ', '
+  end
+  output = output.chomp(', ')
+else
+  output << 'N/A'
+end
+puts output


### PR DESCRIPTION
PagerDuty has deprecated v1 of the REST API so I have migrated your code to v2. In addition, I made a few other changes to the code:
1. Updated code to be within the [RuboCop](https://github.com/bbatsov/rubocop) style guidelines
2. Updated the code to handle users with multiple email and/or phone contact methods
3. Updated the second command line argument to be a service over a schedule. I think this is more useful as it will list the currently on-call user for the service regardless of whether the escalation policy tied to the service has a schedule on level one or just has the user added as level one. If you disagree I'm happy to close the PR and submit another based upon a schedule ID argument.

I ran a few tests on my end but please feel free to run a few tests as well and plug this into IRC before merging!
